### PR TITLE
Added option to use recaptcha.net as api root and agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ $ npm i @nestlab/google-recaptcha
             secretKey: process.env.GOOGLE_RECAPTCHA_SECRET_KEY,
             response: req => req.headers.recaptcha,
             skipIf: () => process.env.NODE_ENV !== 'production',
+            // If your server has trouble connecting to https://www.google.com
+            // You can use https://recaptcha.net instead
+            // Or use an agent (see proxy-agent NPM module)
+            useRecaptchaNet: false,
+            agent: null
         })
     ],
 })

--- a/src/interfaces/google-recaptcha-validator-options.ts
+++ b/src/interfaces/google-recaptcha-validator-options.ts
@@ -1,3 +1,15 @@
+import * as https from "https";
+
 export interface GoogleRecaptchaValidatorOptions {
     secretKey: string;
+    /**
+     * If your server has trouble connecting to https://www.google.com,
+     * set it to `true` to use https://recaptcha.net instead.
+     */
+    useRecaptchaNet?: boolean;
+    /**
+     * If your server has trouble connecting to https://www.google.com,
+     * you can use an agent (`proxy-agent` or other NPM modules)
+     */
+    agent?: https.Agent;
 }

--- a/src/services/google-recaptcha.validator.ts
+++ b/src/services/google-recaptcha.validator.ts
@@ -8,6 +8,7 @@ import { ErrorCode } from '../enums/error-code';
 @Injectable()
 export class GoogleRecaptchaValidator {
     private readonly apiUrl = 'https://www.google.com/recaptcha/api/siteverify';
+    private readonly apiUrlUseRecaptchaNet = 'https://recaptcha.net/recaptcha/api/siteverify';
     private readonly headers = {'Content-Type': 'application/x-www-form-urlencoded'};
 
     constructor(private readonly http: HttpService,
@@ -17,7 +18,12 @@ export class GoogleRecaptchaValidator {
     validate(response: string): Promise<GoogleRecaptchaValidationResult> {
         const data = qs.stringify({secret: this.options.secretKey, response});
 
-        return this.http.post(this.apiUrl, data, {headers: this.headers})
+        return this.http.post(
+            this.options.useRecaptchaNet ? this.apiUrlUseRecaptchaNet : this.apiUrl, data, {
+                headers: this.headers,
+                httpsAgent: this.options.agent
+            }
+        )
             .toPromise()
             .then(res => res.data)
             .then(result => ({

--- a/test/google-recaptcha-async-module.spec.ts
+++ b/test/google-recaptcha-async-module.spec.ts
@@ -17,6 +17,8 @@ export class TestConfigService {
             secretKey: 'secret',
             response: req => req.body.recaptcha,
             skipIf: () => true,
+            useRecaptchaNet: false,
+            agent: null
         };
     }
 }

--- a/test/google-recaptcha-module.spec.ts
+++ b/test/google-recaptcha-module.spec.ts
@@ -14,6 +14,8 @@ describe('Google recaptcha module', () => {
                     secretKey: process.env.GOOGLE_RECAPTCHA_SECRET_KEY,
                     response: req => req.headers.authorization,
                     skipIf: () => process.env.NODE_ENV !== 'production',
+                    useRecaptchaNet: false,
+                    agent: null
                 })
             ],
         }).compile();


### PR DESCRIPTION
In China, many people, even unskilled server administrators, have trouble connecting to https://www.google.com. Luckily Google has another domain for reCAPTCHA https://recaptcha.net, which has local server in China. I added an options `useRecaptchaNet` like [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) for these people.

And, I also added an `agent` option for skilled administrators to use a proxy to connect to Google.