### PR TITLE
Compat with NestJS 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,25 +33,27 @@
   },
   "homepage": "https://github.com/chvarkov/google-recaptcha",
   "peerDependencies": {
-    "@nestjs/core": ">=6.0.0 <9.0.0",
-    "@nestjs/common": ">=6.0.0 <9.0.0"
+    "@nestjs/axios": ">=0.0.1 <1.0.0",
+    "@nestjs/common": ">=8.0.0 <10.0.0",
+    "@nestjs/core": ">=8.0.0 <10.0.0"
   },
   "devDependencies": {
-    "@nestjs/common": "^6.0.0",
-    "@nestjs/core": "^6.0.0",
-    "@nestjs/graphql": "^7.9.8",
-    "@nestjs/platform-express": "^6.11.11",
-    "@nestjs/testing": "^6.11.11",
-    "@types/express": "^4.17.11",
-    "@types/jest": "^24.9.1",
-    "@types/node": "^12.12.14",
-    "jest": "^24.9.0",
+    "@nestjs/axios": "^0.1.0",
+    "@nestjs/common": "^9.0.5",
+    "@nestjs/core": "^9.0.5",
+    "@nestjs/graphql": "^10.0.21",
+    "@nestjs/platform-express": "^9.0.5",
+    "@nestjs/testing": "^9.0.5",
+    "@types/express": "^4.17.13",
+    "@types/jest": "^28.1.6",
+    "@types/node": "^18.0.6",
+    "jest": "^28.1.3",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^6.5.4",
-    "ts-jest": "^24.2.0",
-    "ts-loader": "^8.0.0",
-    "ts-node": "^8.5.2",
-    "typescript": "^3.7.2"
+    "rxjs": "^7.5.6",
+    "ts-jest": "^28.0.7",
+    "ts-loader": "^9.3.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.7.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/services/google-recaptcha.validator.ts
+++ b/src/services/google-recaptcha.validator.ts
@@ -1,4 +1,4 @@
-import { HttpService, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { GoogleRecaptchaValidatorOptions } from '../interfaces/google-recaptcha-validator-options';
 import { RECAPTCHA_HTTP_SERVICE, RECAPTCHA_OPTIONS } from '../provider.declarations';
 import * as qs from 'querystring';
@@ -10,6 +10,7 @@ import { VerifyResponseOptions } from '../interfaces/verify-response-decorator-o
 import { VerifyResponseV2, VerifyResponseV3 } from '../interfaces/verify-response';
 import { ErrorCode } from '../enums/error-code';
 import { GoogleRecaptchaNetworkException } from '../exceptions/google-recaptcha-network.exception';
+import { HttpService } from "@nestjs/axios";
 
 @Injectable()
 export class GoogleRecaptchaValidator {


### PR DESCRIPTION
Since NestJS 8 `HttpService` is deprecated on `@nestjs/common` and belongs to `@nestjs/axios`, version 9 has removed it

Fixes https://github.com/chvarkov/google-recaptcha/issues/63