### PR TITLE
fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Get verification result
 export class FeedbackController {
     @Recaptcha()
     @Post('send')
-    async send(@RecaptchaResult() recaptchaResult: GoogleRecaptchaValidationResult): Promise<any> {
+    async send(@RecaptchaResult() recaptchaResult: RecaptchaVerificationResult): Promise<any> {
         console.log(`Action: ${recaptchaResult.action} Score: ${recaptchaResult.score}`);
         // TODO: Your implementation.
     }


### PR DESCRIPTION
# Description

Example in readme used interface `GoogleRecaptchaValidationResult` which seems to be dropped in #71 if favour of `RecaptchaVerificationResult`. When tried to use `@Recaptcha` decorator as per example, got an error message. Seems like correct update, pls tell me if I am wrong. Also this is the only mention of `GoogleRecaptchaValidationResult` in whole codebase.
Thank you for a nice module, adding recaptcha to project now and it does a great magic!

# How Has This Been Tested?
Was not tested, documentation update.

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] reCAPTCHA V2 HTTP
- [ ] reCAPTCHA V2 GraphQL
- [ ] reCAPTCHA V3 HTTP
- [ ] reCAPTCHA V3 GraphQL
- [ ] reCAPTCHA Enterprise HTTP
- [ ] reCAPTCHA Enterprise GraphQL

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
